### PR TITLE
Client-side deletion with callback

### DIFF
--- a/ActionColumn.php
+++ b/ActionColumn.php
@@ -254,6 +254,7 @@ class ActionColumn extends \yii\grid\ActionColumn
                 $options = ArrayHelper::merge(
                     [
                         'title' => $title,
+                        'data-pjax' => '0',
                     ],
                     $options
                 );
@@ -269,7 +270,6 @@ class ActionColumn extends \yii\grid\ActionColumn
                         [
                             'data-confirm' => Yii::t('kvgrid', 'Are you sure to delete this item?'),
                             'data-method' => 'post',
-                            'data-pjax' => '0'
                         ], $options
                     );
                 }

--- a/ActionColumn.php
+++ b/ActionColumn.php
@@ -160,11 +160,46 @@ class ActionColumn extends \yii\grid\ActionColumn
      */
     protected $_isDropdown = false;
 
+    /**
+     * @var boolean affects the Delete button only. Specifies whether the form row
+     * delete request is sent to the server for processing (false) or performed on
+     * the client (true) by removing the tabular form grid row. Client-deletion does
+     * not affect the record in the database. In this case, the deleted records need
+     * to be identified and processed on the server after form submission. Defaults
+     * to `false`.
+     */
+    public $clientDelete = false;
+
+    /**
+     * @var string an optional client-side JavaScript callback function to call after
+     * performing client-side deletion. It can be passed either as a function name
+     * or anonymous function as shown below:
+     *
+     * - Calling a function:
+     * 'clientDeleteCallback' => 'postDeleteRow'
+     * To call a function similar to:
+     * function postDeleteRow(key) {alert('Row with key '+key+' has been deleted.');}
+     *
+     * - Using an anonymous function:
+     * 'clientDeleteCallback' => new JsExpression(
+     *      "function(key) {alert('Row with key '+key+' has been deleted.');}"
+     * )
+     *
+     * Where `key` is the id of the deleted record. This parameter is effective only
+     * if `clientDelete` is true.
+     */
+    public $clientDeleteCallback;
+
     public function init()
     {
         $this->_isDropdown = ($this->grid->bootstrap && $this->dropdown);
         if (!isset($this->header)) {
             $this->header = Yii::t('kvgrid', 'Actions');
+        }
+        if($this->clientDelete) {
+            $view = $this->grid->view;
+            ActionColumnAsset::register($view);
+            $view->registerJs('kvDeleteRow("'.$this->grid->options['id'].'"'.(!empty($this->clientDeleteCallback) ? ', '.$this->clientDeleteCallback : '').')');
         }
         $this->parseFormat();
         $this->parseVisibility();
@@ -219,12 +254,25 @@ class ActionColumn extends \yii\grid\ActionColumn
                 $options = ArrayHelper::merge(
                     [
                         'title' => $title,
-                        'data-confirm' => Yii::t('kvgrid', 'Are you sure to delete this item?'),
-                        'data-method' => 'post',
-                        'data-pjax' => '0'
                     ],
                     $options
                 );
+                if ($this->clientDelete) {
+                    $url = '#';
+                    $options = ArrayHelper::merge(
+                        [
+                            'data-delete' => Yii::t('kvgrid', 'Are you sure to delete this item?'),
+                        ], $options
+                    );
+                } else {
+                    $options = ArrayHelper::merge(
+                        [
+                            'data-confirm' => Yii::t('kvgrid', 'Are you sure to delete this item?'),
+                            'data-method' => 'post',
+                            'data-pjax' => '0'
+                        ], $options
+                    );
+                }
                 if ($this->_isDropdown) {
                     $options['tabindex'] = '-1';
                     return '<li>' . Html::a($label, $url, $options) . '</li>' . PHP_EOL;

--- a/ActionColumnAsset.php
+++ b/ActionColumnAsset.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @package   yii2-grid
+ * @author    Yasser Hassan <yhassan@yahoo.com>
+ * @copyright Copyright &copy; Kartik Visweswaran, Krajee.com, 2014 - 2015
+ * @version   3.0.1
+ */
+
+namespace kartik\grid;
+
+/**
+ * Asset bundle for GridView ActionColumn
+ *
+ * @author Yasser Hassan <yhassan@yahoo.com>
+ * @since
+ */
+class ActionColumnAsset extends \kartik\base\AssetBundle
+{
+    /**
+     * @inheritdoc
+     */
+    public function init() {
+        $this->setSourcePath(__DIR__.'/assets');
+        $this->setupAssets('js', ['js/kv-grid-actions']);
+        parent::init();
+    }
+}

--- a/assets/js/kv-grid-actions.js
+++ b/assets/js/kv-grid-actions.js
@@ -1,0 +1,32 @@
+/*!
+ * @package   yii2-grid
+ * @author    Yasser Hassan <yhassan@yahoo.com>
+ * @copyright Copyright &copy; Kartik Visweswaran, Krajee.com, 2014 - 2015
+ * @version   3.0.1
+ *
+ * Client actions for yii2-grid ActionColumn
+ * 
+ * Author: Yasser Hassan
+ * Copyright: 2015, Kartik Visweswaran, Krajee.com
+ * For more JQuery plugins visit http://plugins.krajee.com
+ * For more Yii related demos visit http://demos.krajee.com
+ */
+var kvDeleteRow = function(gridId, callback) {
+    "use strict";
+    (function($) {
+        var $grid = $('#'+gridId);
+        $grid.find("a[data-delete]").on('click', function(e) {
+            //$el = $(this);
+            var message = $(this).data('delete');
+            if(confirm(message)) {
+                var $row = $(this).parents("tr:first");
+                var key = $row.data('key');
+                $row.remove();
+                if(callback && typeof(callback) === 'function') {
+                    callback(key);
+                }
+            }
+            e.preventDefault();
+        });
+    })(window.jQuery);
+};


### PR DESCRIPTION
A feature to delete grid rows on the client side with the option to use a callback function for further processing on the client if required. Currently it should be used only in tabular forms as the deletion process would not be complete without form submission and execution on the server.

The callback could be used to collect the IDs of the deleted rows/records in a hidden input to submit them with the form to the server to execute the actual deletion from the database. Another option is to compare the submitted records with the ones in the database to identify which ones should be deleted.

The callback should not be used to attempt to delete the records using AJAX as there's no way to undelete a row if the call failed.

This feature aims at streamlining the user experience with grids and tabular forms. More features are expected later including:
- An optional pre-delete function that could be used to confirm deleting the record on the server via an AJAX call prior to deleting it on the client. This can extend the client-side deletion to grid views without form and deleting detail records in master-detail forms without form submission.
- Adding new rows to the grid. Typically the contents would be filled out in a dialog box then used to add the new row.

>Note: Grid changes need to be applied on the server to be preserved through grid page navigation.