### PR TITLE
Allow initialization of ExpandRowColumn cells even if they are hidden

### DIFF
--- a/assets/js/kv-grid-expand.js
+++ b/assets/js/kv-grid-expand.js
@@ -78,7 +78,7 @@ kvExpandRow = function (options) {
                 $detail = $el.find('.kv-expanded-row'),
                 vKey = $detail.data('key'),
                 vInd = $detail.data('index'),
-                cols = $row.find('td:visible').length;
+                cols = $row.find('td').length;
 
             if (!isExpanded($icon) && !isCollapsed($icon)) {
                 return true;


### PR DESCRIPTION
Related to fix #261 - the previous fix allowed for initialisation, but
all content in the expanded row would only have a colspan of 1 as
opposed to the amount of columns in the grid.