### PR TITLE
Zero width joiner for excel exports

### DIFF
--- a/controllers/ExportController.php
+++ b/controllers/ExportController.php
@@ -37,6 +37,8 @@ class ExportController extends \yii\web\Controller
             $config = Json::decode($config);
             $this->generatePDF($content, "{$name}.pdf", $config);
             return;
+        }else if ($type == GridView::EXCEL) {
+            $content = str_replace('<td>', '<td>&zwnj;', $content);
         }
         $this->setHttpHeaders($type, $name, $mime, $encoding);
         return $content;


### PR DESCRIPTION
This line of code will fix this bug I've found in my applications:

When I was exporting a GridView all cell values starting with a zero (0) where cutted of, so the zero was gone. By adding a zero width non-joiner (zwnj) in front of the cell values the problem is gone. This fix is only for excel files, as they are the only file type that has problems with leading zeros.

I don't know if this is really a fix for something, just wanted to let you know and offer a solution.