### PR TITLE
Improved the leading zero handling

### DIFF
--- a/controllers/ExportController.php
+++ b/controllers/ExportController.php
@@ -38,7 +38,12 @@ class ExportController extends \yii\web\Controller
             $this->generatePDF($content, "{$name}.pdf", $config);
             return;
         } elseif ($type == GridView::EXCEL) {
-            $content = str_replace('<td>', '<td>&zwnj;', $content);
+           $matches = array();
+           preg_match_all('/<td>([0-9]+)<\/td>/', $content, $matches);
+           foreach ($matches[0] as $match) {
+             $match_without_td = str_replace('<td>', '', str_replace('</td>', '', $match));
+             $content = str_replace($match, '<td style="vnd.ms-excel.numberformat:' . str_repeat('0', strlen($match_without_td)) . '">' . $match_without_td . '</td>', $content);
+           }
         }
         $this->setHttpHeaders($type, $name, $mime, $encoding);
         return $content;


### PR DESCRIPTION
I've seen some issues with the old work around. For example: If there was a date field "09.12.2015" it would be replaced by "&zwnj;09.12.2015" this would cause that the date column would be not sortable anymore. Also the values where declared as text values (that's logical, but very uncomfortable).

So now the Controller is looking for td-tags that contains numbers only. They will be extended by the vnd.ms-excel.numberformat attribute, that will show the leading zeros and is sortable too!

This attribute is tested with Excel 2010, maybe some other users can have a look at it with other versions?

Also it is possible to use vnd.ms-excel.numberformat:@ instead of filling it up with the exact number of zeros. But that will cause showing a green upper left corner in the cell saying it is a number saved as text. 

I will do some research on this to get even more improvements in this issue.