### PR TITLE
Add options to set resizableColumns plugin options

### DIFF
--- a/GridView.php
+++ b/GridView.php
@@ -355,6 +355,11 @@ HTML;
     public $resizableColumns = true;
 
     /**
+     * @var boolean whether to allow resizing of columns
+     */
+    public $resizableColumnsOptions = [];
+    
+    /**
      * @var boolean whether to store resized column state using local storage persistence
      * (supported by most modern browsers). Defaults to `false`.
      */
@@ -1441,14 +1446,16 @@ HTML;
             }
         }
         if ($this->resizableColumns) {
-            $store = '{store:null}';
+            $rcDefaults=[];
             if ($this->persistResize) {
                 GridResizeStoreAsset::register($view);
-                $store = '';
+            } else {
+                $rcDefaults=['store'=>null];
             }
+            $rcOptions=Json::encode(ArrayHelper::merge($rcDefaults, $this->resizableColumnsOptions));
             $contId = $this->containerOptions['id'];
             GridResizeColumnsAsset::register($view);
-            $script .= "$('#{$contId}').resizableColumns({$store});";
+            $script .= "$('#{$contId}').resizableColumns({$rcOptions});";
         }
         if ($this->floatHeader) {
             GridFloatHeadAsset::register($view);


### PR DESCRIPTION
If you look in the resizableColumns jQuery plugin there are some options that can be set...

```javascript

    ResizableColumns.prototype.defaults = {
      selector: 'tr th:visible',
      store: window.store,
      syncHandlers: true,
      resizeFromBody: true,
      maxWidth: null,
      minWidth: null
    };
```

I added the 'resizableColumnsOptions' property to the GridView so that the plugin options can be set.