### PR TITLE
Enable users to define own conversions for icons

### DIFF
--- a/GridView.php
+++ b/GridView.php
@@ -941,11 +941,11 @@ HTML;
             return;
         }
         $this->exportConversions = ArrayHelper::merge(
+            $this->exportConversions,
             [
                 ['from' => self::ICON_ACTIVE, 'to' => Yii::t('kvgrid', 'Active')],
                 ['from' => self::ICON_INACTIVE, 'to' => Yii::t('kvgrid', 'Inactive')]
-            ],
-            $this->exportConversions
+            ]
         );
 
         $this->export = ArrayHelper::merge(


### PR DESCRIPTION
To enable users to define own conversions for the icons GridView::ICON_ACTIVE and GridView::ICON_INACTIVE it is necessary to change the order of the conversion in the exportConversions array. The users conversions have to be before the predefined conversions.