### PR TITLE
fix number '1' that appear below the pagination footer panel

### DIFF
--- a/GridView.php
+++ b/GridView.php
@@ -192,7 +192,6 @@ HTML;
     <div class="kv-panel-pager">
         {pager}
     </div>
-    {footer}
     <div class="clearfix"></div>
 HTML;
 


### PR DESCRIPTION
I use your panel with this setting
```php
'panel' => [
            'heading'=>'<h3 class="panel-title"><i class="fa fa-file-text-o"></i> Laporan Staff</h3>',
            'before' => false,
            'after' => false,
            'type'=>'primary',
            'footer'=>true
        ],
```
And you will see number '1' below the pagination, in the bottom left corner, like picture below
![screenshot from 2016-03-09 20 35 57](https://cloud.githubusercontent.com/assets/5893840/13637030/b2ef5378-e637-11e5-8353-3f069117d9f1.png)

I change GridView.php from
```php
<div class="kv-panel-pager">
    {pager}
</div>
{footer}
<div class="clearfix"></div>
```
to
```php
<div class="kv-panel-pager">
    {pager}
</div>
<div class="clearfix"></div>
```