### PR TITLE
Having different editable models in one gridview column

### DIFF
--- a/EditableColumnAction.php
+++ b/EditableColumnAction.php
@@ -102,6 +102,11 @@ class EditableColumnAction extends Action
      * @var bool whether to allow access to this action for AJAX requests only. Defaults to `true`.
      */
     public $ajaxOnly = true;
+    
+    /**
+     * @var string allows overriding the form name which is used to access posted data
+     */
+    public $formName = '';
 
     /**
      * @inheritdoc
@@ -145,11 +150,14 @@ class EditableColumnAction extends Action
         }
         $index = ArrayHelper::getValue($post, 'editableIndex');
         $attribute = ArrayHelper::getValue($post, 'editableAttribute');
-        $formName = $model->formName();
+        if ($this->formName) // allow override for getting the data
+            $formName = $this->formName;
+        else
+            $formName = $model->formName();
         if (!$formName || is_null($index) || !isset($post[$formName][$index])) {
             return ['output' => '', 'message' => Yii::t('kvgrid', 'Invalid editable index or model form name')];
         }
-        $postData = [$formName => $post[$formName][$index]];
+        $postData = [$model->formName() => $post[$formName][$index]]; // still use model's form name
         if ($model->load($postData)) {
             $params = [$model, $attribute, $key, $index];
             $value = static::parseValue($this->outputValue, $params);

--- a/EditableColumnAction.php
+++ b/EditableColumnAction.php
@@ -150,14 +150,17 @@ class EditableColumnAction extends Action
         }
         $index = ArrayHelper::getValue($post, 'editableIndex');
         $attribute = ArrayHelper::getValue($post, 'editableAttribute');
-        if ($this->formName) // allow override for getting the data
+        
+        if ($this->formName) {
             $formName = $this->formName;
-        else
+        } else {
             $formName = $model->formName();
+        }
+        
         if (!$formName || is_null($index) || !isset($post[$formName][$index])) {
             return ['output' => '', 'message' => Yii::t('kvgrid', 'Invalid editable index or model form name')];
         }
-        $postData = [$model->formName() => $post[$formName][$index]]; // still use model's form name
+        $postData = [$model->formName() => $post[$formName][$index]];
         if ($model->load($postData)) {
             $params = [$model, $attribute, $key, $index];
             $value = static::parseValue($this->outputValue, $params);


### PR DESCRIPTION
I've set up editable colums using your [webtip](http://webtips.krajee.com/rapidly-setup-gridview-editable-cells-with-editable-column-action/)
I had some problems with having attributes from different models in my gridview, which should also be editable.
This is how the columns are defined:
```
    [
        'class' => '\kartik\grid\EditableColumn',
        'attribute' => 'city',
        'editableOptions' => [
            'header'  => 'City',
            'formOptions' => ['action' => ['/master/edit_city']],
            'inputType' => \kartik\editable\Editable::INPUT_DROPDOWN_LIST,
            'data' => Master::getCityArray(),
        ]
    ],
    [
        'class' => '\kartik\grid\EditableColumn',
        'attribute' => 'status',
        'editableOptions' => [
            'header'  => 'Status',
            'formOptions' => ['action' => ['/master/edit_status']],   
            'inputType' => \kartik\editable\Editable::INPUT_DROPDOWN_LIST,
            'data' => Slave::getStatusArray(),
            // Slave is the real model of the attribute "status", however the actions() for saving it is in the MasterController to have it in one place
        ]
    ],
```

To be able to have the correct values in the grid for `status`, I had to insert a `getStatus()` in `Master`, which just gets the value from the related model. This is a workaround because I could not get `EditableColumn` to work with a column configuration of `attribute` and `value` like it is used for related models with `DataColumn`.

This is how `actions()` in `MasterController` looks:
```
   public function actions()
   {
        return ArrayHelper::merge(parent::actions(), [
            'edit_city' => [
                'class' => EditableColumnAction::className(),
                'modelClass' => Master::className(),
            ],
            'edit_status' => [
                'class' => EditableColumnAction::className(),
                'modelClass' => Slave::className(),
            ],
        ]);
    }
```

With this, the related `$master->slave->status` is shown in the grid and editable, however it cannot be saved. When trying to save, one gets an `Invalid editable index or model form name` error. This is because the submitted data will be submitted as `Master[status_id][id]`. But `EditableColumnActions` checks for `if (!$formName || is_null($index) || !isset($post[$formName][$index]))` so the last portion will fail, as `$formName` equals `Slave`.

The patch will allow to override the `$formName`, so `Master[status_id][id]` can also be accepted as data for `Slave`. The `actions()` for relevant models should then be modified like this:
```
   public function actions()
   {
        return ArrayHelper::merge(parent::actions(), [
            'edit_city' => [
                'class' => EditableColumnAction::className(),
                'modelClass' => Master::className(),
            ],
            'edit_status' => [
                'class' => EditableColumnAction::className(),
                'modelClass' => Slave::className(),
                'formName' => Master::className(),
            ],
        ]);
    }
```

This is probably not the most straight-forward solution, but it won't break normal editable fields and give more customization options.

As there normally is only one field submitted by an `EditableColumn`, maybe it would be better to remove the model's classname from the `name` attribute of `EditableColumn`s? The configured `modelClass` in `actions()` would take care of different models anyway.