### PR TITLE
Fix toggle data minCount validation

### DIFF
--- a/GridView.php
+++ b/GridView.php
@@ -1490,7 +1490,7 @@ HTML;
             return '';
         }
         $minCount = ArrayHelper::getValue($this->toggleDataOptions, 'minCount', 0);
-        if ($minCount !== true && (!$minCount || $minCount <= $this->dataProvider->getTotalCount())) {
+        if ($minCount !== true && (!$minCount || $minCount >= $this->dataProvider->getTotalCount())) {
             return '';
         }
         $event = $this->pjax ? 'pjax:click' : 'click';


### PR DESCRIPTION
The logic that defines the appearance of the "toggle data" confirmation message was inverted.
The message appears only when the record number is below minCount.... that's wrong.

Fixed It.