### PR TITLE
fix problem when using nested ExpandRowColumn

### DIFF
--- a/ExpandRowColumn.php
+++ b/ExpandRowColumn.php
@@ -346,13 +346,14 @@ class ExpandRowColumn extends DataColumn
         $detailOptions['data-index'] = $index;
         $detailOptions['data-key'] = !is_string($key) && !is_numeric($key) ?
             (is_array($key) ? Json::encode($key) : (string)$key) : $key;
-        Html::addCssClass($detailOptions, 'kv-expanded-row');
-        $content = Html::tag('div', $detail, $detailOptions);
         $id = $this->grid->options['id'];
+        Html::addCssClass($detailOptions, 'kv-expanded-row');
+        Html::addCssClass($detailOptions, $id);
+        $content = Html::tag('div', $detail, $detailOptions);
         return <<< HTML
         <div class="kv-expand-row {$id}{$disabled}">
-            <div class="kv-expand-icon kv-state-{$type}{$disabled}">{$icon}</div>
-            <div class="kv-expand-detail skip-export" style="display:none;">
+            <div class="kv-expand-icon kv-state-{$type}{$disabled} {$id}">{$icon}</div>
+            <div class="kv-expand-detail skip-export {$id}" style="display:none;">
                 {$content}
             </div>
         </div>

--- a/assets/js/kv-grid-expand.js
+++ b/assets/js/kv-grid-expand.js
@@ -94,6 +94,7 @@ var kvRowNum = 0, kvExpandRow;
         $rows.each(function () {
             var $el = $(this), $newRow, $tr,
                 $icon = $el.find('.kv-expand-icon.' + gridId),
+                $icons = $el.find('.kv-expand-icon'),
                 $row = $el.closest('tr'),
                 $cell = $el.closest('.kv-expand-icon-cell'),
                 $container = $el.find('.kv-expand-detail.' + gridId),
@@ -157,13 +158,13 @@ var kvRowNum = 0, kvExpandRow;
                 collapseRow = function () {
                     beginLoading($cell);
                     $container.html('');
-                    $icon.html(expandIcon);
+                    $icons.html(expandIcon);
                     $cell.attr('title', expandTitle);
                     $tr = $detail.closest('.kv-expand-detail-row');
                     $detail.slideUp(duration, function () {
                         $detail.unwrap().unwrap();
                         $detail.appendTo($container);
-                        setExpanded($icon);
+                        setExpanded($icons);
                     });
                     endLoading($cell);
                 },

--- a/assets/js/kv-grid-expand.js
+++ b/assets/js/kv-grid-expand.js
@@ -93,11 +93,11 @@ var kvRowNum = 0, kvExpandRow;
         }
         $rows.each(function () {
             var $el = $(this), $newRow, $tr,
-                $icon = $el.find('.kv-expand-icon'),
+                $icon = $el.find('.kv-expand-icon.' + gridId),
                 $row = $el.closest('tr'),
                 $cell = $el.closest('.kv-expand-icon-cell'),
-                $container = $el.find('.kv-expand-detail'),
-                $detail = $el.find('.kv-expanded-row'),
+                $container = $el.find('.kv-expand-detail.' + gridId),
+                $detail = $el.find('.kv-expanded-row.' + gridId),
                 vKey = $detail.data('key'),
                 vInd = $detail.data('index');
             if (!isExpanded($icon) && !isCollapsed($icon)) {


### PR DESCRIPTION
This change fixes #558

EDIT, the problem described below is now fixed

a problem remains:
- expand the level0 row
- expand the level1 row
- collapse the level0 row
- expand the level0 row

You will see that the level1 row has the expanded icon, but does not have the row expanded