### PR TITLE
Fixed issue #572: Silently disable PDF when dependency is not available.

### DIFF
--- a/GridView.php
+++ b/GridView.php
@@ -1379,6 +1379,12 @@ HTML;
                 ],
             ],
         ];
+
+        // Remove PDF if dependency is not loaded.
+        if (!class_exists(\kartik\mpdf\Pdf::class)) {
+            unset($defaultExportConfig[self::PDF]);
+        }
+
         $this->exportConfig = self::parseExportConfig($this->exportConfig, $defaultExportConfig);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
             "kartik\\grid\\": ""
         }
     },
+    "suggest": {
+        "kartik-v/yii2-mpdf": "For exporting grids to PDF"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "3.1.x-dev"


### PR DESCRIPTION
## Scope
This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-grid/blob/master/CHANGE.md)):

- Changed the default configuration so that PDF export is disabled when the required dependency is not available.

## Related Issues
#572
