### PR TITLE
Fix for integrating resizableColumns and floatThead.

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -3,6 +3,12 @@ Change Log: `yii2-grid`
 
 ## Version 3.1.4
 
+**Date:** 25-Feb-2017
+
+1. (enh #624): Call floatThead('reflow') after resizing columns so that the floating head is also resized.
+
+## Version 3.1.4
+
 **Date:** 03-Jan-2017
 
 1. (enh #542): More correct group summation.

--- a/CHANGE.md
+++ b/CHANGE.md
@@ -5,7 +5,7 @@ Change Log: `yii2-grid`
 
 **Date:** 25-Feb-2017
 
-1. (enh #624): Call floatThead('reflow') after resizing columns so that the floating head is also resized.
+1. (bug #624): Call floatThead('reflow') after resizing columns so that the floating head is also resized.
 
 ## Version 3.1.4
 

--- a/GridView.php
+++ b/GridView.php
@@ -1817,8 +1817,8 @@ HTML;
             $script .= "$('#{$gridId} .kv-grid-table:first').floatThead({$opts});";
             // integrate resizeableColumns with floatThead
             if ($this->resizableColumns) {
-                $view->registerJs("$('#{$contId}').on('column:resize:stop', function(e){"
-                . " $('#{$gridId} .kv-grid-table:nth-child(2)').floatThead('reflow'); });");
+                $view->registerJs("$('#{$contId}').on('column:resize', function(e){"
+                    . " $('#{$gridId} .kv-grid-table:nth-child(2)').floatThead('reflow'); });");
             }
         }
         if ($this->perfectScrollbar) {

--- a/GridView.php
+++ b/GridView.php
@@ -1815,6 +1815,11 @@ HTML;
             $this->floatHeaderOptions = array_replace_recursive($opts, $this->floatHeaderOptions);
             $opts = Json::encode($this->floatHeaderOptions);
             $script .= "$('#{$gridId} .kv-grid-table:first').floatThead({$opts});";
+            // integrate resizeableColumns with floatThead
+            if ($this->resizableColumns) {
+                $view->registerJs("$('#{$contId}').on('column:resize:stop', function(e){"
+                . " $('#{$gridId} .kv-grid-table:nth-child(2)').floatThead('reflow'); });");
+            }
         }
         if ($this->perfectScrollbar) {
             GridPerfectScrollbarAsset::register($view);


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-grid/blob/master/CHANGE.md)):

- Call floatThead('reflow') after resizing columns so that the floating head is also resized.

## Related Issues
kartik-v/yii2-dynagrid/issues/146
#560

## Other

It should be noted in the documentation that in order to get resizableColumns and floatThead to work together the `position` in `floatHeaderOptions` must be set to `absolute`.