### PR TITLE
Enhance ExpandRowColumn behavior when used along with grid grouping

### DIFF
--- a/assets/js/kv-grid-expand.js
+++ b/assets/js/kv-grid-expand.js
@@ -158,6 +158,19 @@ var kvRowNum = 0, kvExpandRow;
                         $detail.show();
                         setCollapsed($icon);
                     }
+                    // needed when used together with grouping
+                    var $rowsBefore = $row.prevAll();
+                    $rowsBefore.push($row);
+                    var expandRowPosition = $row.index() + 1;
+                    $.each($rowsBefore, function (i, tr) {
+                        var $rowSpanTds = $(tr).find('td[rowspan]');
+                        $.each($rowSpanTds, function(j, td) {
+                            var rowSpan = parseInt($(td).attr('rowspan'));
+                            if ($(tr).index() + rowSpan > expandRowPosition) {
+                                $(td).attr('rowspan', rowSpan + 1);
+                            }
+                        });
+                    });
                     if (detailUrl.length === 0) {
                         endLoading($cell);
                     }
@@ -172,6 +185,19 @@ var kvRowNum = 0, kvExpandRow;
                         $detail.unwrap().unwrap();
                         $detail.appendTo($container);
                         setExpanded($icons);
+                        // needed when used together with grouping
+                        var $rowsBefore = $row.prevAll();
+                        $rowsBefore.push($row);
+                        var expandRowPosition = $row.index() + 1;
+                        $.each($rowsBefore, function (i, tr) {
+                            var $rowSpanTds = $(tr).find('td[rowspan]');
+                            $.each($rowSpanTds, function(j, td) {
+                                var rowSpan = parseInt($(td).attr('rowspan'));
+                                if ($(tr).index() + rowSpan > expandRowPosition) {
+                                    $(td).attr('rowspan', rowSpan - 1);
+                                }
+                            });
+                        });
                     });
                     endLoading($cell);
                 },


### PR DESCRIPTION
There's a bug when using ExpandRowColumn together with grid grouping. There is a bug report about it: #609
The problem was that the `<td>`'s rowspan attribute wasn't updated when a row was expanded.

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-grid/blob/master/CHANGE.md)):

- fixed #609

## Related Issues
#609 