### PR TITLE
fix stopped event broadcast

### DIFF
--- a/assets/js/kv-grid-action.js
+++ b/assets/js/kv-grid-action.js
@@ -21,6 +21,7 @@ var kvActionDelete;
             if (!options.proceed) {
                 e.stopPropagation();
                 e.preventDefault();
+                $(document).trigger('show.bs.modal');
                 lib.confirm(opts.msg, function (result) {
                     if (!result) {
                         return;


### PR DESCRIPTION
Hi, Kartik-v!

I needed to perform some action on the event 'show.bs.modal', but because of e.stopPropagation(); its impossible... May be you can add this line (or something else) for fix it?

## Scope
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-grid/blob/master/CHANGE.md)):

- added 'show.bs.modal' event broadcast before modal window is present.

## Related Issues
If this is related to an existing ticket, include a link to it as well.