### PR TITLE
Update GridView.php

### DIFF
--- a/GridView.php
+++ b/GridView.php
@@ -1852,7 +1852,7 @@ HTML;
         }
         if ($this->perfectScrollbar) {
             GridPerfectScrollbarAsset::register($view);
-            $script .= '{$container}.perfectScrollbar(' . Json::encode($this->perfectScrollbarOptions) . ');';
+            $script .= $container . '.perfectScrollbar(' . Json::encode($this->perfectScrollbarOptions) . ');';
         }
         $this->genToggleDataScript();
         $script .= $this->_toggleScript;


### PR DESCRIPTION
Fixes JS error when enabling `perfectScrollbar` on a grid.
The `$container` variable wasn't recognized between `''` and it causes a JS error.

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-grid/blob/master/CHANGE.md)):

-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.