### PR TITLE
Correct French Translations

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -16,6 +16,7 @@ Change Log: `yii2-grid`
     - Enhance translations for all message files
 - Update contribution templates.
 - (enh #702, #703): Update German, Italian, and French translations.
+- (bug #726): Fixed translation key for French language.
 
 ## Version 3.1.6
 

--- a/messages/fr/kvgrid.php
+++ b/messages/fr/kvgrid.php
@@ -30,7 +30,7 @@ return [
     'PDF' => 'PDF',
     'Page' => 'Page',
     'Portable Document Format' => 'Portable Document Format',
-    'Showing <b>{begin, number}-{end, number}</b> of <b>{totalCount, number}</b> {totalCount, plural, one{item} other{items}}.' => 'Affichage de <b>{begin, number}-{end, number}</b> sur <b>{totalCount, number}</b> {totalCount, plural, one{{item}} other{{items}}}.',
+    'Showing <b>{begin, number}-{end, number}</b> of <b>{totalCount, number}</b> {totalCount, plural, one{{item}} other{{items}}}.' => 'Affichage de <b>{begin, number}-{end, number}</b> sur <b>{totalCount, number}</b> {totalCount, plural, one{{item}} other{{items}}}.',
     'Total <b>{count, number}</b> {count, plural, one{{item}} other{{items}}}.' => 'Total <b>{count, number}</b> {count, plural, one{{item}} few{{items-few}} many{{items-many}} other{{items}}}.',
     'Yii2 Grid Export (PDF)' => 'Yii2 Grid Export (PDF)',
     'grid-export' => 'grid-export',


### PR DESCRIPTION
French translation bug fix

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-grid/blob/master/CHANGE.md)):

- (bug #726): Fixed translation key for French language.

## Related Issues
https://github.com/kartik-v/yii2-grid/issues/726