### PR TITLE
Update to prevent 'Uncaught TypeError: $ is not a function' errors

### DIFF
--- a/GridView.php
+++ b/GridView.php
@@ -1893,7 +1893,7 @@ HTML;
             $gridOptsVar = 'kvGridExp_' . hash('crc32', $gridOpts);
             $view->registerJs("var {$gridOptsVar}={$gridOpts};", View::POS_HEAD);
             foreach ($this->exportConfig as $format => $setting) {
-                $id = "$('#{$gridId} .export-{$format}')";
+                $id = "jQuery('#{$gridId} .export-{$format}')";
                 $genOpts = Json::encode(
                     [
                         'filename' => $setting['filename'],
@@ -1918,7 +1918,7 @@ HTML;
                 $script .= "{$id}.gridexport({$expOptsVar});";
             }
         }
-        $container = '$("#' . $this->containerOptions['id'] . '")';
+        $container = 'jQuery("#' . $this->containerOptions['id'] . '")';
         if ($this->resizableColumns) {
             $rcDefaults = [];
             if ($this->persistResize) {
@@ -1945,11 +1945,11 @@ HTML;
             }
             $this->floatHeaderOptions = array_replace_recursive($opts, $this->floatHeaderOptions);
             $opts = Json::encode($this->floatHeaderOptions);
-            $script .= "$('#{$gridId} .kv-grid-table:first').floatThead({$opts});";
+            $script .= "jQuery('#{$gridId} .kv-grid-table:first').floatThead({$opts});";
             // integrate resizeableColumns with floatThead
             if ($this->resizableColumns) {
                 $script .= "{$container}.off('{$NS}').on('column:resize{$NS}', function(e){" .
-                    '$("#{$gridId} .kv-grid-table:nth-child(2)").floatThead("reflow");' .
+                    'jQuery("#{$gridId} .kv-grid-table:nth-child(2)").floatThead("reflow");' .
                     '});';
             }
         }


### PR DESCRIPTION
Update to prevent 'Uncaught TypeError: $ is not a function' errors via pjax calls on GridView filters etc

Yii Framework 2.0.13.1

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes

- changed $ to jQuery in script injected via `$view->registerJs()`