### PR TITLE
Unused local variable 'grid'. 

### DIFF
--- a/GridView.php
+++ b/GridView.php
@@ -1702,7 +1702,6 @@ HTML;
         $postPjaxJs = "setTimeout({$this->_gridClientFunc}, 2500);";
         $pjaxCont = '$("#' . $this->pjaxSettings['options']['id'] . '")';
         if ($loadingCss !== false) {
-            $grid = 'jQuery("#' . $this->containerOptions['id'] . '")';
             if ($loadingCss === true) {
                 $loadingCss = 'kv-grid-loading';
             }


### PR DESCRIPTION
Hi!
Remove unused local variable 'grid'. The value of the variable is not used anywhere.

## Scope
This pull request includes a

- [* ] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-grid/blob/master/CHANGE.md)):

-Remove unused local variable 'grid'. 
