### PR TITLE
Fix parsing of placeholders {export} and {toggleData}

### DIFF
--- a/GridView.php
+++ b/GridView.php
@@ -1651,7 +1651,14 @@ HTML;
         $toggleData = $this->renderToggleData();
         $replace = [];
         if (strpos($this->layout, '{toolbarContainer}') > 0) {
-            $replace['{toolbarContainer}'] = $this->renderToolbarContainer();
+            $toolbarContainer = strtr(
+                $this->renderToolbarContainer(),
+                [
+                    '{export}' => $export,
+                    '{toggleData}' => $toggleData,
+                ]
+            );
+            $replace['{toolbarContainer}'] = $toolbarContainer;
         }
         if (strpos($this->layout, '{toolbar}') > 0) {
             $toolbar = strtr(
@@ -1821,8 +1828,7 @@ HTML;
      */
     protected function renderToolbarContainer()
     {
-        $tag = ArrayHelper::remove($this->toolbarContainerOptions, 'div');
-        return Html::tag($tag, $this->renderToolbar(), $this->toolbarContainerOptions);
+        return Html::tag('div', $this->renderToolbar(), $this->toolbarContainerOptions);
     }
 
     /**


### PR DESCRIPTION
## Scope
This pull request includes a

- \[x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-grid/blob/master/CHANGE.md)):

- Parsing of placeholders {export} and {toggleData} for toolbarContainer 
- Added a div to renderToolbarContainer because otherwise the default toolbarContainerOptions are applied to a null tag

## Related Issues
This should fix #748 