### PR TITLE
Switch from yii2-money to yii2-number

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -18,6 +18,7 @@ Change Log: `yii2-grid`
 - (enh #733): More correct `jQuery` usage.
 - (bug #730): Fix comma errors in message files.
 - (enh #729): Update Polish Translations.
+- (bug #770): Switch from yii2-money to yii2-number.
 
 ## Version 3.1.7
 

--- a/GridView.php
+++ b/GridView.php
@@ -201,9 +201,9 @@ class GridView extends YiiGridView
      */
     const FILTER_SLIDER = '\kartik\slider\Slider';
     /**
-     * Grid filter input type for [[\kartik\money\MaskMoney]] widget
+     * Grid filter input type for [[\kartik\number\NumberControl]] widget
      */
-    const FILTER_MONEY = '\kartik\money\MaskMoney';
+    const FILTER_NUMBER = '\kartik\number\NumberControl';
     /**
      * Grid filter input type for [[\kartik\checkbox\CheckboxX]] widget
      */


### PR DESCRIPTION
yii2-money is obsolete and has been replaced by yii2-number.

## Scope
This pull request includes a

- [x] Bug fix
- [x] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-grid/blob/master/CHANGE.md)):

- Switch from yii2-money to yii2-number

## Related Issues

#770.
