### PR TITLE
remove row on collapse when detailUrl given

### DIFF
--- a/assets/js/kv-grid-expand.js
+++ b/assets/js/kv-grid-expand.js
@@ -182,7 +182,11 @@ var kvRowNum = 0, kvExpandRow;
                     $tr = $detail.closest('.kv-expand-detail-row');
                     $detail.slideUp(duration, function () {
                         $detail.unwrap().unwrap();
-                        $detail.appendTo($container);
+                        if (detailUrl.length === 0) {
+                            $detail.appendTo($container);
+                        } else {
+                            $detail.remove();
+                        }
                         setExpanded($icons);
                         // needed when used together with grouping
                         var $rowsBefore = $row.prevAll();


### PR DESCRIPTION
It used to be like this, but something changed. The result is hidden checkboxes are checked with "check all".  Please revert to the old functionality where it removes from the dom when it's hidden.
