### PR TITLE
Bugfix typo in dialogLib-Name: must be ucfirst. Fixing wrong call to …

### DIFF
--- a/src/GridView.php
+++ b/src/GridView.php
@@ -1939,7 +1939,7 @@ HTML;
                 $view->registerJs("var {$genOptsVar}={$genOpts};", View::POS_HEAD);
                 $expOpts = Json::encode(
                     [
-                        'dialogLib' => ArrayHelper::getValue($this->krajeeDialogSettings, 'libName', 'krajeeDialog'),
+                        'dialogLib' => ArrayHelper::getValue($this->krajeeDialogSettings, 'libName', 'KrajeeDialog'),
                         'gridOpts' => new JsExpression($gridOptsVar),
                         'genOpts' => new JsExpression($genOptsVar),
                         'alertMsg' => ArrayHelper::getValue($setting, 'alertMsg', false),

--- a/src/assets/js/kv-grid-export.js
+++ b/src/assets/js/kv-grid-export.js
@@ -186,7 +186,7 @@
                 if (isEmpty(msg)) {
                     return;
                 }
-                lib.confirm(msg, function (result) {
+                lib.prototype.confirm(msg, function (result) {
                     if (result) {
                         self.processExport(callback, arg);
                     }
@@ -386,6 +386,6 @@
         });
     };
 
-    $.fn.gridexport.defaults = {dialogLib: 'krajeeDialog'};
+    $.fn.gridexport.defaults = {dialogLib: 'KrajeeDialog'};
     $.fn.gridexport.Constructor = GridExport;
 })(window.jQuery);


### PR DESCRIPTION
…lib.confirm.

## Scope
This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-grid/blob/master/CHANGE.md)):

- Bugfix typo in dialogLib-Name: must be ucfirst.
- Fixing wrong call to lib.confirm: must be lib.prototype.confirm
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.