### PR TITLE
Fix typo in check if has xlFormat

### DIFF
--- a/src/ColumnTrait.php
+++ b/src/ColumnTrait.php
@@ -228,7 +228,7 @@ trait ColumnTrait
     public function parseExcelFormats(&$options, $model, $key, $index)
     {
         $autoFormat = $this->grid->autoXlFormat;
-        if (!isset($this->xlsFormat) && !$autoFormat) {
+        if (!isset($this->xlFormat) && !$autoFormat) {
             return;
         }
         $fmt = '';


### PR DESCRIPTION
Class has 'xlFormat' property but the check is against $this->xlsFormat

## Scope
This pull request includes a

- [x ] Bug fix
- [ ] New feature
- [ ] Translation

