### PR TITLE
Harmonized asset namespace to allow asset compression without errors

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,6 +1,9 @@
 Change Log: `yii2-grid`
 =======================
 
+**Date:** 19-Nov-2018
+- (enh #859): harmonized asset namespaces
+
 ## Version 3.2.8
 
 **Date:** 09-Nov-2018

--- a/src/GridViewAsset.php
+++ b/src/GridViewAsset.php
@@ -24,7 +24,7 @@ class GridViewAsset extends AssetBundle
      */
     public function init()
     {
-        $this->depends = array_merge(["\\kartik\\dialog\\DialogAsset"], $this->depends);
+        $this->depends = array_merge(["kartik\\dialog\\DialogAsset"], $this->depends);
         $this->setSourcePath(__DIR__ . '/assets');
         $this->setupAssets('css', ['css/kv-grid']);
         parent::init();


### PR DESCRIPTION
When you compress your assets you get an `yii\base\InvalidConfigException` beacause of `kartik\dialog\DialogBootstrapAsset` and `kartik\grid\GridViewAsset`. `kartik\dialog\DialogBoostrapAsset` depends on `kartik\dialog\DialogAsset` like this: 
```php
$this->depends = array_merge(['kartik\dialog\DialogAsset'], $this->depends);
```
and `kartik\grid\GridViewAsset` like this:
```php
$this->depends = array_merge(["\\kartik\\dialog\\DialogAsset"], $this->depends);
```
This results in a double asset load loop and produces the following error
> Invalid Configuration – yii\base\InvalidConfigException
   An asset bundle that depends on 'all' has a higher javascript file position configured than 'all'.

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-grid/blob/master/CHANGE.md)):

- harmonized asset namespaces

## Related Issues
If this is related to an existing ticket, include a link to it as well.