### PR TITLE
fix init floatThead

### DIFF
--- a/src/GridView.php
+++ b/src/GridView.php
@@ -2159,7 +2159,7 @@ HTML;
             }
             $this->floatHeaderOptions = array_replace_recursive($opts, $this->floatHeaderOptions);
             $opts = Json::encode($this->floatHeaderOptions);
-            $script .= "jQuery('#{$gridId} .kv-grid-table:first').floatThead({$opts});";
+            $script .= "jQuery('#{$gridId} .kv-grid-table').floatThead({$opts});";
             // integrate resizeableColumns with floatThead
             if ($this->resizableColumns) {
                 $script .= "{$container}.off('{$NS}').on('column:resize{$NS}', function(e){" .


### PR DESCRIPTION
Without a pseudo-class, first floatThead works, but not with it. The selector does not find the table.
Need to use either:

```php
$opts = Json::encode($this->floatHeaderOptions);
$script .= "jQuery('#{$gridId} .kv-grid-table').floatThead({$opts});";
```
or

```php
$opts = Json::encode($this->floatHeaderOptions);
$selectorTable = $this->tableOptions['id'] ?? "{$gridId} .kv-grid-table";
$script .= "jQuery('#{$selectorTable}').floatThead({$opts});";
```

## Scope
This pull request includes a
- [x] Bug fix
