### PR TITLE
Allow setting page summary colspan direction (`ltr` or `rtl`)

### DIFF
--- a/src/GridView.php
+++ b/src/GridView.php
@@ -190,6 +190,16 @@ class GridView extends YiiGridView implements BootstrapInterface
     const ALIGN_BOTTOM = 'bottom';
 
     /**
+     * @var int horizontal right position for merge of colspan at page summary
+     */
+    const SPAN_RIGHT = 0;
+
+    /**
+     * @var int horizontal left position for merge of colspan at page summary
+     */
+    const SPAN_LEFT = 1;
+
+    /**
      * @var string CSS to apply to prevent wrapping of grid cell data
      */
     const NOWRAP = 'kv-nowrap';
@@ -1233,11 +1243,17 @@ HTML;
             if (!empty($column->pageSummaryOptions['colspan'])) {
                 $span = (int) $column->pageSummaryOptions['colspan'];
                 if ($span > 0) {
-                    $skipCols = range($i + 1, $i + $span - 1);
-                    $skipped = array_merge($skipCols, $skipped);
+                    if(empty($column->pageSummaryOptions['colSpanDir'])){
+                        $skipCols = range($i + 1, $i + $span - 1);
+                        $skipped = array_merge($skipCols, $skipped);
+                    }else{
+                        $skipCols = range($i - $span + 1, $i - 1);
+                        $skipped = array_merge($skipCols, $skipped);
+                    }
                 }
             }
         }
+
         if (!empty($skipped )) {
             for ($i = 0; $i < $cols; $i++) {
                 if (in_array($i, $skipped )) {


### PR DESCRIPTION
Added the possibility to choose the side of column pageSummaryOptions['colspan'] must merge (left or right side) using pageSummaryOptions['colSpanDir'] attribute at column level. 
Otherwise, today the colspan only works LTR so i've added the possibility of RTL merge.

## Scope
This pull request includes a
- [x] New feature

## Related Issues
https://github.com/kartik-v/yii2-grid/issues/902