### PR TITLE
Fix "Unparenthesized `a ? b : c ? d : e` is deprecated"

### DIFF
--- a/src/ColumnTrait.php
+++ b/src/ColumnTrait.php
@@ -288,7 +288,7 @@ trait ColumnTrait
                     break;
                 case 'currency':
                     $curr = is_array($this->format) && isset($this->format[1]) ? $this->format[1] :
-                        isset($formatter->currencyCode) ? $formatter->currencyCode . ' ' : '';
+                        (isset($formatter->currencyCode) ? $formatter->currencyCode . ' ' : '');
                     $fmt = "{$curr}\\#\\{$tSep}\\#\\#0{$dSep}00";
                     break;
                 case 'date':


### PR DESCRIPTION
(https://github.com/kartik-v/yii2-grid/issues/934)

Fixes plugin work under PHP 7.4

## Scope
This pull request includes a

- [x ] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-grid/blob/master/CHANGE.md)):

-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.