### PR TITLE
Select 2 Filter with multiple option showing error: Array to string conversion 

### DIFF
--- a/src/DataColumn.php
+++ b/src/DataColumn.php
@@ -250,6 +250,8 @@ class DataColumn extends YiiDataColumn
      */
     protected function renderFilterCellContent()
     {
+        $content='';
+        if($this->filterType=="")
         $content = parent::renderFilterCellContent();
         $chkType = !empty($this->filterType) && $this->filterType !== GridView::FILTER_CHECKBOX &&
             $this->filterType !== GridView::FILTER_RADIO && !class_exists($this->filterType);


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

Below error is coming when we using the Filter as select2 in grid with multiple option true.
PHP Notice – yii\base\ErrorException
Array to string conversion
<img width="1655" alt="Screenshot 2021-01-11 at 2 43 49 PM" src="https://user-images.githubusercontent.com/9700282/104162965-96748180-541b-11eb-9ea2-e82fd0cb064d.png">


## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-grid/blob/master/CHANGE.md)):

We added a if condition in DataColumn.php at line number 253, to check if filterType is coming as blank only then we need to call the parent function : parent::renderFilterCellContent(); 
As in case of select2 it's trying to render Html::activeTextInput due that error is coming
-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.