### PR TITLE
Added compatibility with 8.1 for trim()

### DIFF
--- a/src/ColumnTrait.php
+++ b/src/ColumnTrait.php
@@ -447,7 +447,7 @@ trait ColumnTrait
             Html::addCssClass($this->pageSummaryOptions, $class);
             Html::addCssClass($this->footerOptions, $class);
         }
-        if (trim($this->width) != '') {
+        if (null !== $this->width && trim($this->width) != '') {
             Html::addCssStyle($this->headerOptions, "width:{$this->width};");
             Html::addCssStyle($this->pageSummaryOptions, "width:{$this->width};");
             Html::addCssStyle($this->footerOptions, "width:{$this->width};");
@@ -516,7 +516,7 @@ trait ColumnTrait
         if ($this->isValidAlignment('vAlign')) {
             Html::addCssClass($options, "kv-align-{$this->vAlign}");
         }
-        if (trim($this->width) != '') {
+        if (null !== $this->width && trim($this->width) != '') {
             Html::addCssStyle($options, "width:{$this->width};");
         }
         $options['data-col-seq'] = array_search($this, $this->grid->columns);


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-grid/blob/master/CHANGE.md)):

- Added check in the null before trim() function for width parameter

## Related Issues
#1016