### PR TITLE
Nested ExpandColumn deletes top levels content

### DIFF
--- a/src/assets/js/kv-grid-expand.js
+++ b/src/assets/js/kv-grid-expand.js
@@ -285,7 +285,7 @@ var kvExpandRow;
                 if (!isAjax) {
                     beginLoading($cell);
                 }
-                $grid.find('tr[data-index="' + vInd + '"]').remove();
+                $grid.find('tr[data-index="' + vKey + '"]').remove();
                 $detail.hide();
                 $row.after($detail);
                 var newRow = '<tr class="kv-expand-detail-row ' + rowCssClass + '" data-key="' + vKey +


### PR DESCRIPTION
When a third level nestedColumn expands, it deletes the top level elements

## Scope
This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
If you need sub-nested grids with expandable columns the index is not a valid indetiffier, so when you expand a sub-grid, with different records, it will drop the top-level with the same index