### PR TITLE
Persist resize uniq column ids

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,6 +1,10 @@
 Change Log: `yii2-grid`
 =======================
 
+## Version 3.5.2
+ - ability to set custom "resizable-colimn-id" for resizable colums
+     - set via column's `headerOptions['data-resizable-column-id']` property
+
 ## Version 3.5.1
 
 **Date:** 17-Jun-2022

--- a/src/GridView.php
+++ b/src/GridView.php
@@ -140,7 +140,7 @@ class GridView extends YiiGridView implements BootstrapInterface, GridViewInterf
         $cells = [];
         foreach ($this->columns as $index => $column) {
             /* @var DataColumn $column */
-            if ($this->resizableColumns && $this->persistResize) {
+            if ($this->resizableColumns && $this->persistResize && !isset($column->headerOptions['data-resizable-column-id'])) {
                 $column->headerOptions['data-resizable-column-id'] = "kv-col-{$index}";
             }
             $cells[] = $column->renderHeaderCell();


### PR DESCRIPTION
## Scope
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-grid/blob/master/CHANGE.md)):

- ability to set custom "resizable-colimn-id" for resizable colums
     - set via column's `headerOptions['data-resizable-column-id']` property
