### PR TITLE
Added previous existing class back to the export form

### DIFF
--- a/src/assets/js/kv-grid-export.js
+++ b/src/assets/js/kv-grid-export.js
@@ -308,7 +308,7 @@
                 self.popup.focus();
                 self.setPopupAlert(self.messages.downloadProgress);
             }
-            $('<form/>', {'action': self.action, 'target': target, 'method': 'post', css: {'display': 'none'}})
+            $('<form/>', {'action': self.action, 'class': 'kv-export-form', 'target': target, 'method': 'post', css: {'display': 'none'}})
                 .append(getInput('export_filetype', type), getInput('export_filename', self.filename))
                 .append(getInput('export_encoding', self.encoding), getInput('export_bom', self.bom ? 1 : 0))
                 .append(getInput('export_content', content), getInput('module_id', self.module), $csrf)


### PR DESCRIPTION
Back in version 3.2.7, when the export form was enhanced, the class which the form originally had got removed, this PR puts it back again. I had some cases where I would listen to a submit event in this form, and I'm using that class as the way to get this form.

This fixes the export form class that was removed in https://github.com/kartik-v/yii2-grid/commit/fb00ef48203673df92b7944139c945a893df9913.