### PR TITLE
fix #1066

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "kartik-v/yii2-grid",
+  "name": "spo0okie/yii2-grid",
   "description": "Yii 2 GridView on steroids. Various enhancements and utilities for the Yii 2.0 GridView widget.",
   "keywords": [
     "yii2",

--- a/src/assets/js/jquery.resizableColumns.js
+++ b/src/assets/js/jquery.resizableColumns.js
@@ -25,14 +25,16 @@ var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments)
       syncHandlers: true,
       resizeFromBody: true,
       maxWidth: null,
-      minWidth: null
+      minWidth: null,
+      visWaitTimeout: 0,
     };
 
-    function ResizableColumns($table, options) {
-      this.pointerdown = __bind(this.pointerdown, this);
-      this.constrainWidth = __bind(this.constrainWidth, this);
-      this.options = $.extend({}, this.defaults, options);
-      this.$table = $table;
+    ResizableColumns.prototype.initTable = function() {
+      if (this.visWaitTimeout && this.$table && !this.$table.is(":visible")) {
+        let _this = this;
+        setTimeout(function(){_this.initTable()},this.options.visWaitTimeout);
+        return;
+      }
       this.setHeaders();
       this.restoreColumnWidths();
       this.syncHandleWidths();
@@ -49,6 +51,18 @@ var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments)
       }
       if (this.options.stop) {
         this.$table.bind('column:resize:stop.rc', this.options.stop);
+      }
+    }
+
+    function ResizableColumns($table, options) {
+      this.pointerdown = __bind(this.pointerdown, this);
+      this.constrainWidth = __bind(this.constrainWidth, this);
+      this.options = $.extend({}, this.defaults, options);
+      this.$table = $table;
+      if (options==='destroy') {
+        this.destroy();
+      } else {
+        this.initTable();
       }
     }
 
@@ -70,7 +84,7 @@ var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments)
     };
 
     ResizableColumns.prototype.destroy = function() {
-      this.$handleContainer.remove();
+      if (this.$handleContainer) this.$handleContainer.remove();
       this.$table.removeData('resizableColumns');
       return this.$table.add(window).off('.rc');
     };


### PR DESCRIPTION
set visWaitTimeout in ms to defer intialization until table become visible

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-grid/blob/master/CHANGE.md)):

- If gridView renders invisible and option "visWaitTimeout" for Resizable Columns is set, then resizable columns initialization will repeatedly defer itself for visWaitTimeout ms, until table become visible

## Related Issues
issue 1066