### PR TITLE
Fixed the syntax for Unparenthesized  issue in PHP 8.2

### DIFF
--- a/src/ColumnTrait.php
+++ b/src/ColumnTrait.php
@@ -279,8 +279,8 @@ trait ColumnTrait
                     $fmt = ($format == 'scientific') ? "0{$append}E+00" : "\\#\\{$tSep}\\#\\#0" . $append;
                     break;
                 case 'currency':
-                    $curr = is_array($this->format) && isset($this->format[1]) ? $this->format[1] :
-                        (isset($formatter->currencyCode) ? $formatter->currencyCode . ' ' : '');
+                    $curr = (is_array($this->format) && isset($this->format[1])) ? $this->format[1] :
+                     (isset($formatter->currencyCode) ? $formatter->currencyCode . ' ' : '');
                     $fmt = "{$curr}\\#\\{$tSep}\\#\\#0{$dSep}00";
                     break;
                 case 'date':


### PR DESCRIPTION
I was facing the issue when run the package in PHP 8.2 with yii2 framework.

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-grid/blob/master/CHANGE.md)):

-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.